### PR TITLE
Use correct repository for gradle 3.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,10 @@
 
 buildscript {
     repositories {
-        jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
gradle 3.x is not available is jcenter but is in Google's Maven repository.
Also upgraded to gradle 3.0.1 at Android Studio's prompting.