### PR TITLE
Improve tests by creating base class and tried to make less flaky and made sure all tests use test server.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,11 +67,11 @@ dependencies {
     // Optional -- Hamcrest library
     androidTestImplementation 'org.hamcrest:hamcrest-library:1.3'
     // Optional -- UI testing with Espresso
-    //    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
     //https://stackoverflow.com/questions/45541666/espresso-test-failing-no-interface-method-trackusage-in-usagetracker-java
     androidTestImplementation('com.android.support.test.espresso:espresso-core:3.0.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
+    androidTestImplementation 'com.android.support.test.espresso:espresso-contrib:3.0.2'
     // Optional -- UI testing with UI Automator
     //  androidTestCompile 'com.android.support.test.uiautomator:uiautomator-v18:2.1.2'
     testImplementation 'junit:junit:4.12'

--- a/app/src/androidTest/java/nz/org/cacophony/birdmonitor/CreateAccountTest.java
+++ b/app/src/androidTest/java/nz/org/cacophony/birdmonitor/CreateAccountTest.java
@@ -14,11 +14,15 @@ import static nz.org.cacophony.birdmonitor.HelperCode.nowNavigateRight;
 
 public class CreateAccountTest extends TestBaseStartingOnSetupScreen {
 
+    private static final String TEST_USERNAME_PREFIX = "cacophonometer_test_";
+    private static final String TEST_EMAIL_DOMAIN = "@test.test";
+    private static final String TEST_PASSWORD = "test_password";
+
     private String uniqueId;
 
     @Before
     public void setUpForCreateAccount() {
-        uniqueId = "cacophonometer_test_" + UUID.randomUUID();
+        uniqueId = TEST_USERNAME_PREFIX + UUID.randomUUID();
 
         nowNavigateRight();// takes you to Create Account screen
     }
@@ -26,9 +30,9 @@ public class CreateAccountTest extends TestBaseStartingOnSetupScreen {
     @Test
     public void createAccountTest() {
         onView(withId(R.id.etUsername)).perform(replaceText(uniqueId), closeSoftKeyboard());
-        onView(withId(R.id.etEmail)).perform(replaceText(uniqueId + "@test.test"), closeSoftKeyboard());
-        onView(withId(R.id.etPassword1)).perform(replaceText("Pppother1"), closeSoftKeyboard());
-        onView(withId(R.id.etPassword2)).perform(replaceText("Pppother1"), closeSoftKeyboard());
+        onView(withId(R.id.etEmail)).perform(replaceText(uniqueId + TEST_EMAIL_DOMAIN), closeSoftKeyboard());
+        onView(withId(R.id.etPassword1)).perform(replaceText(TEST_PASSWORD), closeSoftKeyboard());
+        onView(withId(R.id.etPassword2)).perform(replaceText(TEST_PASSWORD), closeSoftKeyboard());
 
         onView(withId(R.id.btnSignUp)).perform(click());
 

--- a/app/src/androidTest/java/nz/org/cacophony/birdmonitor/CreateAccountTest.java
+++ b/app/src/androidTest/java/nz/org/cacophony/birdmonitor/CreateAccountTest.java
@@ -1,67 +1,26 @@
 package nz.org.cacophony.birdmonitor;
 
-import android.content.Context;
-import android.support.test.espresso.IdlingRegistry;
-import android.support.test.filters.LargeTest;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.runner.AndroidJUnit4;
-import org.junit.*;
-import org.junit.runner.RunWith;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.util.UUID;
 
-import static android.support.test.InstrumentationRegistry.getInstrumentation;
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.*;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withSubstring;
-import static nz.org.cacophony.birdmonitor.HelperCode.nowSwipeLeft;
+import static nz.org.cacophony.birdmonitor.HelperCode.nowNavigateRight;
 
-@LargeTest
-@RunWith(AndroidJUnit4.class)
-public class CreateAccountTest {
+public class CreateAccountTest extends TestBaseStartingOnSetupScreen {
 
     private String uniqueId;
-
-    @Rule
-    public final ActivityTestRule<MainActivity> mActivityTestRule = new ActivityTestRule<>(MainActivity.class);
-
-    @BeforeClass
-    public static void registerIdlingResource() {
-        IdlingRegistry.getInstance().register(IdlingResourceForEspressoTesting.createAccountIdlingResource);
-        IdlingRegistry.getInstance().register(IdlingResourceForEspressoTesting.registerPhoneIdlingResource);
-        IdlingRegistry.getInstance().register(IdlingResourceForEspressoTesting.signInIdlingResource);
-        IdlingRegistry.getInstance().register(IdlingResourceForEspressoTesting.anyWebRequestResource);
-    }
-
-    @AfterClass
-    public static void unregisterIdlingResource() {
-        IdlingRegistry.getInstance().unregister(IdlingResourceForEspressoTesting.createAccountIdlingResource);
-        IdlingRegistry.getInstance().unregister(IdlingResourceForEspressoTesting.registerPhoneIdlingResource);
-        IdlingRegistry.getInstance().unregister(IdlingResourceForEspressoTesting.signInIdlingResource);
-        IdlingRegistry.getInstance().unregister(IdlingResourceForEspressoTesting.anyWebRequestResource);
-    }
 
     @Before
     public void setUpForCreateAccount() {
         uniqueId = "cacophonometer_test_" + UUID.randomUUID();
 
-        Context targetContext = getInstrumentation().getTargetContext();
-        Prefs prefs = new Prefs(targetContext);
-        prefs.setInternetConnectionMode("normal");
-
-        if (prefs.getDeviceName() == null) {
-            // Welcome Dialog WILL be displayed - and SetupWizard will be running
-            HelperCode.dismissWelcomeDialog();
-        } else {
-            // Main menu will be showing
-            onView(withId(R.id.btnSetup)).perform(click());
-        }
-
-        HelperCode.signOutUser(prefs);
-        HelperCode.useTestServerAndShortRecordings();
-        nowSwipeLeft();// takes you to Create Account screen
+        nowNavigateRight();// takes you to Create Account screen
     }
 
     @Test

--- a/app/src/androidTest/java/nz/org/cacophony/birdmonitor/DeleteRecordingsTest.java
+++ b/app/src/androidTest/java/nz/org/cacophony/birdmonitor/DeleteRecordingsTest.java
@@ -1,113 +1,38 @@
 package nz.org.cacophony.birdmonitor;
 
-import android.content.Context;
-import android.support.test.espresso.IdlingRegistry;
-import android.support.test.filters.LargeTest;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.rule.GrantPermissionRule;
-import android.support.test.runner.AndroidJUnit4;
-import org.junit.*;
-import org.junit.runner.RunWith;
+import org.junit.Before;
+import org.junit.Test;
 
-import static android.Manifest.permission.*;
-import static android.support.test.InstrumentationRegistry.getInstrumentation;
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
-import static nz.org.cacophony.birdmonitor.HelperCode.nowSwipeLeft;
+import static nz.org.cacophony.birdmonitor.HelperCode.nowNavigateRight;
+import static nz.org.cacophony.birdmonitor.HelperCode.nowNavigateRightTimes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@LargeTest
-@RunWith(AndroidJUnit4.class)
-public class DeleteRecordingsTest {
-
-    private Context targetContext;
-    private Prefs prefs;
-
-    @Rule
-    public final ActivityTestRule<MainActivity> mActivityTestRule = new ActivityTestRule<>(MainActivity.class);
-
-    @Rule
-    public GrantPermissionRule permissionRule = GrantPermissionRule.grant(
-            WRITE_EXTERNAL_STORAGE,
-            RECORD_AUDIO,
-            ACCESS_FINE_LOCATION,
-            READ_PHONE_STATE);
-
-    @BeforeClass
-    public static void registerIdlingResource() {
-        IdlingRegistry.getInstance().register(IdlingResourceForEspressoTesting.recordIdlingResource);
-        IdlingRegistry.getInstance().register(IdlingResourceForEspressoTesting.signInIdlingResource);
-        IdlingRegistry.getInstance().register(IdlingResourceForEspressoTesting.anyWebRequestResource);
-    }
-
-    @AfterClass
-    public static void unregisterIdlingResource() {
-        IdlingRegistry.getInstance().unregister(IdlingResourceForEspressoTesting.recordIdlingResource);
-        IdlingRegistry.getInstance().unregister(IdlingResourceForEspressoTesting.signInIdlingResource);
-        IdlingRegistry.getInstance().unregister(IdlingResourceForEspressoTesting.anyWebRequestResource);
-    }
+public class DeleteRecordingsTest extends TestBaseStartingOnSetupScreen {
 
     @Before
     public void setUpForDeleteAllRecordings() throws InterruptedException {
-        targetContext = getInstrumentation().getTargetContext();
-        prefs = new Prefs(targetContext);
-
-        prefs.setInternetConnectionMode("normal");
-
-        // Need to make sure app isn't disabled, so 'RECORD NOW' button is visible/enabled
-        prefs.setIsDisabled(true);
-
-
-        if (prefs.getDeviceName() == null) {
-            // Welcome Dialog WILL be displayed - and SetupWizard will be running
-            HelperCode.dismissWelcomeDialog();
-        } else {
-            // Main menu will be showing
-            onView(withId(R.id.btnSetup)).perform(click());
-        }
-
-        Util.unregisterPhone(targetContext);
-        Util.signOutUser(targetContext);
-
-        nowSwipeLeft();
-        nowSwipeLeft(); // takes you to Sign In screen, which should be showing that user is signed in
-
-        // Need to sign in
+        nowNavigateRightTimes(2);
         HelperCode.signInUserTimhot();
-        Thread.sleep(1000); // had to put in sleep, as could not work out how to consistently get groups to display before testing code tries to choose a group
-
-        nowSwipeLeft(); // takes you to Groups screen
-
+        nowNavigateRight();
         HelperCode.registerPhone(prefs);
 
-        nowSwipeLeft(); // takes you to GPS
-        prefs.setIsDisabled(false);
-        nowSwipeLeft(); // takes you to Test RecordAndSaveOnPhone
+        nowNavigateRightTimes(2); // takes you to Test RecordAndSaveOnPhone
 
         // Need to put phone into offline mode so it doesn't try to upload the recording
         prefs.setInternetConnectionMode("offline");
 
         onView(withId(R.id.btnRecordNow)).perform(click());
 
-        // Need to stop app trying to make more recordings as this stuffs up the upload files idling resource count
-        prefs.setIsDisabled(true);
-
         onView(withId(R.id.btnFinished)).perform(click());
 
         onView(withId(R.id.btnAdvanced)).perform(click());
     }
-
-    @After
-    public void tearDownForDeleteAllRecordings() {
-        prefs.setInternetConnectionMode("normal");
-        Util.signOutUser(targetContext);
-        prefs.setIsDisabled(false);
-    }
-
 
     @Test
     public void deleteRecordingsTest() {

--- a/app/src/androidTest/java/nz/org/cacophony/birdmonitor/DeleteRecordingsTest.java
+++ b/app/src/androidTest/java/nz/org/cacophony/birdmonitor/DeleteRecordingsTest.java
@@ -18,7 +18,7 @@ public class DeleteRecordingsTest extends TestBaseStartingOnSetupScreen {
     @Before
     public void setUpForDeleteAllRecordings() throws InterruptedException {
         nowNavigateRightTimes(2);
-        HelperCode.signInUserTimhot();
+        HelperCode.signInPrimaryTestUser();
         nowNavigateRight();
         HelperCode.registerPhone(prefs);
 

--- a/app/src/androidTest/java/nz/org/cacophony/birdmonitor/GuiControlsTest.java
+++ b/app/src/androidTest/java/nz/org/cacophony/birdmonitor/GuiControlsTest.java
@@ -1,75 +1,34 @@
 package nz.org.cacophony.birdmonitor;
 
-import android.content.Context;
-import android.support.test.filters.LargeTest;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.rule.GrantPermissionRule;
-import android.support.test.runner.AndroidJUnit4;
-import org.junit.*;
-import org.junit.runner.RunWith;
+import org.junit.Ignore;
+import org.junit.Test;
 
-import static android.Manifest.permission.*;
-import static android.support.test.InstrumentationRegistry.getInstrumentation;
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.*;
-import static nz.org.cacophony.birdmonitor.HelperCode.nowSwipeLeft;
-import static nz.org.cacophony.birdmonitor.HelperCode.nowSwipeRight;
+import static nz.org.cacophony.birdmonitor.HelperCode.nowNavigateLeft;
+import static nz.org.cacophony.birdmonitor.HelperCode.nowNavigateRight;
 import static org.junit.Assert.*;
 
-@LargeTest
-@RunWith(AndroidJUnit4.class)
-public class GuiControlsTest {
-
-    private Context targetContext;
-    private Prefs prefs;
-
-    @Rule
-    public final ActivityTestRule<MainActivity> mActivityTestRule = new ActivityTestRule<>(MainActivity.class);
-
-    @Rule
-    public GrantPermissionRule permissionRule = GrantPermissionRule.grant(
-            WRITE_EXTERNAL_STORAGE,
-            RECORD_AUDIO,
-            ACCESS_FINE_LOCATION,
-            READ_PHONE_STATE);
-
-    @Before
-    public void setUpForGuiControls() {
-        targetContext = getInstrumentation().getTargetContext();
-        prefs = new Prefs(targetContext);
-        prefs.setInternetConnectionMode("normal");
-        prefs.setIsDisabled(false);
-
-        if (prefs.getDeviceName() == null) {
-            // Welcome Dialog WILL be displayed - and SetupWizard will be running
-            HelperCode.dismissWelcomeDialog();
-        }
-    }
-
-    @After
-    public void tearDownForGuiControls() {
-        Util.signOutUser(targetContext);
-        prefs.setIsDisabled(true);
-    }
-
+public class GuiControlsTest extends TestBaseStartingOnMainScreen {
 
     @Test
     public void enableOrDisableRecordingTest() {
-        prefs.setIsDisabled(false);
+        prefs.setAutomaticRecordingsDisabled(false);
+
         onView(withId(R.id.btnDisable)).perform(click());
         onView(withId(R.id.swDisable)).perform(click());
         onView(withId(R.id.btnFinished)).perform(click());
 
-        assertTrue(prefs.getIsDisabled());
+        assertTrue(prefs.getAutomaticRecordingsDisabled());
 
         // Now enable the app
         onView(withId(R.id.btnDisable)).perform(click());
         onView(withId(R.id.swDisable)).perform(click());
         onView(withId(R.id.btnFinished)).perform(click());
 
-        assertFalse(prefs.getIsDisabled());
+        assertFalse(prefs.getAutomaticRecordingsDisabled());
     }
 
 
@@ -77,7 +36,7 @@ public class GuiControlsTest {
     public void internetConnectionTest() {
         prefs.setInternetConnectionMode("normal");
         onView(withId(R.id.btnAdvanced)).perform(click());
-        nowSwipeLeft(); // takes you to Internet Connection
+        nowNavigateRight(); // takes you to Internet Connection
 
         // Check Normal selection
         onView(withId(R.id.rbNormal)).check(matches(isChecked()));
@@ -89,8 +48,8 @@ public class GuiControlsTest {
         onView(withId(R.id.rbOnline)).check(matches(isChecked()));
         internetConnectionMode = prefs.getInternetConnectionMode();
         assertEquals("online", internetConnectionMode);
-        nowSwipeRight(); // leave page
-        nowSwipeLeft();  // return to page
+        nowNavigateLeft(); // leave page
+        nowNavigateRight();  // return to page
         onView(withId(R.id.rbOnline)).check(matches(isChecked())); // check Online is still selected
         internetConnectionMode = prefs.getInternetConnectionMode(); // and check still correct in preferences
         assertEquals("online", internetConnectionMode);
@@ -100,8 +59,8 @@ public class GuiControlsTest {
         onView(withId(R.id.rbOffline)).check(matches(isChecked()));
         internetConnectionMode = prefs.getInternetConnectionMode();
         assertEquals("offline", internetConnectionMode);
-        nowSwipeRight(); // leave page
-        nowSwipeLeft();  // return to page
+        nowNavigateLeft(); // leave page
+        nowNavigateRight();  // return to page
         onView(withId(R.id.rbOffline)).check(matches(isChecked())); // check Online is still selected
         internetConnectionMode = prefs.getInternetConnectionMode(); // and check still correct in preferences
         assertEquals("offline", internetConnectionMode);
@@ -114,7 +73,7 @@ public class GuiControlsTest {
         prefs.setPlayWarningSound(false);
 
         onView(withId(R.id.btnAdvanced)).perform(click());
-        HelperCode.nowSwipeLeftTimes(2);
+        HelperCode.nowNavigateRightTimes(2);
 
         onView(withId(R.id.swPlayWarningSound)).check(matches(isNotChecked())); // warning sound should be off
 
@@ -123,8 +82,8 @@ public class GuiControlsTest {
         onView(withId(R.id.swPlayWarningSound)).check(matches(isChecked())); // confirm it is checked
         boolean playWarningSound = prefs.getPlayWarningSound(); // check prefs now indicate to play a warning sound
         assertTrue(playWarningSound);
-        nowSwipeRight(); // leave page
-        nowSwipeLeft();  // return to page
+        nowNavigateLeft(); // leave page
+        nowNavigateRight();  // return to page
         // confirm that prefs and page are still correct
         onView(withId(R.id.swPlayWarningSound)).check(matches(isChecked()));
         playWarningSound = prefs.getPlayWarningSound();
@@ -145,7 +104,7 @@ public class GuiControlsTest {
         prefs.setIgnoreLowBattery(false);
 
         onView(withId(R.id.btnAdvanced)).perform(click());
-        HelperCode.nowSwipeLeftTimes(3);
+        HelperCode.nowNavigateRightTimes(3);
 
         onView(withId(R.id.swIgnoreLowBattery)).check(matches(isNotChecked())); // Ignore Low Battery should be off
 
@@ -154,8 +113,8 @@ public class GuiControlsTest {
         onView(withId(R.id.swIgnoreLowBattery)).check(matches(isChecked())); // confirm it is checked
         boolean ignoreLowBattery = prefs.getIgnoreLowBattery(); // check prefs now indicate to Ignore Low Battery
         assertTrue(ignoreLowBattery);
-        nowSwipeRight(); // leave page
-        nowSwipeLeft();  // return to page
+        nowNavigateLeft(); // leave page
+        nowNavigateRight();  // return to page
         // confirm that prefs and page are still correct
         onView(withId(R.id.swIgnoreLowBattery)).check(matches(isChecked()));
         ignoreLowBattery = prefs.getIgnoreLowBattery();
@@ -176,7 +135,7 @@ public class GuiControlsTest {
         Util.setUseFrequentUploads(targetContext, false);
 
         onView(withId(R.id.btnAdvanced)).perform(click());
-        HelperCode.nowSwipeLeftTimes(4);
+        HelperCode.nowNavigateRightTimes(4);
 
         onView(withId(R.id.swRecordMoreOften)).check(matches(isNotChecked())); // Record more often should be off
         onView(withId(R.id.swUseFrequentUploads)).check(matches(isNotChecked())); // Upload after every recording should be off
@@ -196,8 +155,8 @@ public class GuiControlsTest {
 
         // Now leave the screen and return then check correct radio buttons are still checked
 
-        nowSwipeRight(); // leave page
-        nowSwipeLeft();  // return to page
+        nowNavigateLeft(); // leave page
+        nowNavigateRight();  // return to page
 
         onView(withId(R.id.swRecordMoreOften)).check(matches(isChecked()));
         onView(withId(R.id.swUseFrequentUploads)).check(matches(isNotChecked()));
@@ -222,7 +181,7 @@ public class GuiControlsTest {
         Util.setUseFrequentUploads(targetContext, false);
 
         onView(withId(R.id.btnAdvanced)).perform(click());
-        HelperCode.nowSwipeLeftTimes(4);
+        HelperCode.nowNavigateRightTimes(4);
 
         onView(withId(R.id.swRecordMoreOften)).check(matches(isNotChecked()));
         onView(withId(R.id.swUseFrequentUploads)).check(matches(isNotChecked()));
@@ -241,8 +200,8 @@ public class GuiControlsTest {
 
         // Now leave the screen and return then check correct radio buttons are still checked
 
-        nowSwipeRight(); // leave page
-        nowSwipeLeft();  // return to page
+        nowNavigateLeft(); // leave page
+        nowNavigateRight();  // return to page
 
         onView(withId(R.id.swRecordMoreOften)).check(matches(isNotChecked()));
         onView(withId(R.id.swUseFrequentUploads)).check(matches(isChecked()));
@@ -268,7 +227,7 @@ public class GuiControlsTest {
         Util.setUseFrequentUploads(targetContext, false);
 
         onView(withId(R.id.btnAdvanced)).perform(click());
-        HelperCode.nowSwipeLeftTimes(4);
+        HelperCode.nowNavigateRightTimes(4);
 
         onView(withId(R.id.swRecordMoreOften)).check(matches(isNotChecked()));
         onView(withId(R.id.swUseFrequentUploads)).check(matches(isNotChecked()));
@@ -285,8 +244,8 @@ public class GuiControlsTest {
 
         // Now leave the screen and return then check correct radio buttons are still checked
 
-        nowSwipeRight(); // leave page
-        nowSwipeLeft();  // return to page
+        nowNavigateLeft(); // leave page
+        nowNavigateRight();  // return to page
 
         onView(withId(R.id.swRecordMoreOften)).check(matches(isNotChecked()));
         onView(withId(R.id.swUseFrequentUploads)).check(matches(isNotChecked()));
@@ -307,7 +266,7 @@ public class GuiControlsTest {
         prefs.setHasRootAccess(false);
 
         onView(withId(R.id.btnAdvanced)).perform(click());
-        HelperCode.nowSwipeLeftTimes(5);
+        HelperCode.nowNavigateRightTimes(5);
 
         onView(withId(R.id.swRooted)).check(matches(isNotChecked())); // warning sound should be off
 
@@ -316,8 +275,8 @@ public class GuiControlsTest {
         onView(withId(R.id.swRooted)).check(matches(isChecked())); // confirm it is checked
         boolean isRooted = prefs.getHasRootAccess();
         assertTrue(isRooted);
-        nowSwipeRight(); // leave page
-        nowSwipeLeft();  // return to page
+        nowNavigateLeft(); // leave page
+        nowNavigateRight();  // return to page
         // confirm that prefs and page are still correct
         onView(withId(R.id.swRooted)).check(matches(isChecked()));
         isRooted = prefs.getHasRootAccess();

--- a/app/src/androidTest/java/nz/org/cacophony/birdmonitor/HelperCode.java
+++ b/app/src/androidTest/java/nz/org/cacophony/birdmonitor/HelperCode.java
@@ -23,6 +23,11 @@ import static org.hamcrest.Matchers.is;
 
 class HelperCode {
 
+    private static final String PRIMARY_TEST_USERNAME = "cacophonometer_primary_test_account";
+    private static final String PRIMARY_TEST_PASSWORD = "test_password";
+    private static final String PRIMARY_TEST_GROUP = "cacophonometer_primary_test_group";
+    private static final String TEST_DEVICE_PREFIX = "cacophonometer_test_device_";
+
     public static void useTestServerAndShortRecordings() {
 
         Context targetContext = getInstrumentation().getTargetContext();
@@ -39,6 +44,7 @@ class HelperCode {
         return preferences.getAll();
     }
 
+    @SuppressWarnings("unchecked")
     public static void restorePrefs(Context context, Map<String, ?> backup) {
         SharedPreferences preferences = context.getSharedPreferences(Prefs.PREFS_NAME, Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = preferences.edit();
@@ -84,12 +90,12 @@ class HelperCode {
         onView(allOf(withId(android.R.id.button1), withText("YES"))).perform(scrollTo(), click());
     }
 
-    public static void signInUserTimhot() throws InterruptedException {
+    public static void signInPrimaryTestUser() throws InterruptedException {
         Thread.sleep(1000); // had to put in sleep, as the GUI was replacing the username after I set it below
 
-        onView(withId(R.id.etUserNameOrEmailInput)).perform(replaceText("timhot"), closeSoftKeyboard());
+        onView(withId(R.id.etUserNameOrEmailInput)).perform(replaceText(PRIMARY_TEST_USERNAME), closeSoftKeyboard());
 
-        onView(withId(R.id.etPasswordInput)).perform(replaceText("Pppother1"), closeSoftKeyboard());
+        onView(withId(R.id.etPasswordInput)).perform(replaceText(PRIMARY_TEST_PASSWORD), closeSoftKeyboard());
         onView(withId(R.id.btnSignIn)).perform(click());
         Thread.sleep(1000);
     }
@@ -98,13 +104,13 @@ class HelperCode {
     public static void registerPhone(Prefs prefs) throws InterruptedException {
         Thread.sleep(1000); // had to put in sleep, as could not work out how to consistently get groups to display before testing code tries to choose a group
 
-        onData(allOf(is(instanceOf(String.class)), is("tim1"))).perform(click());
+        onData(allOf(is(instanceOf(String.class)), is(PRIMARY_TEST_GROUP))).perform(click());
 
         // App automatically moves to Register Phone screen
         // Now enter the device name
 
         // Create a unique device name
-        String deviceName  = "cacophonometer_test_device_" + UUID.randomUUID();
+        String deviceName  = TEST_DEVICE_PREFIX + UUID.randomUUID();
         prefs.setLastDeviceNameUsedForTesting(deviceName); // save the device name so can find recordings for it later
 
         onView(withId(R.id.etDeviceNameInput)).perform(replaceText(deviceName), closeSoftKeyboard());

--- a/app/src/androidTest/java/nz/org/cacophony/birdmonitor/RecordAndSaveTest.java
+++ b/app/src/androidTest/java/nz/org/cacophony/birdmonitor/RecordAndSaveTest.java
@@ -18,7 +18,7 @@ public class RecordAndSaveTest extends TestBaseStartingOnSetupScreen {
     @Before
     public void setUpForRecord() throws InterruptedException {
         nowNavigateRightTimes(2);
-        HelperCode.signInUserTimhot();
+        HelperCode.signInPrimaryTestUser();
         nowNavigateRight();
         HelperCode.registerPhone(prefs);
 

--- a/app/src/androidTest/java/nz/org/cacophony/birdmonitor/RecordAndSaveTest.java
+++ b/app/src/androidTest/java/nz/org/cacophony/birdmonitor/RecordAndSaveTest.java
@@ -1,6 +1,5 @@
 package nz.org.cacophony.birdmonitor;
 
-import android.support.test.espresso.Espresso;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/app/src/androidTest/java/nz/org/cacophony/birdmonitor/RecordAndSaveTest.java
+++ b/app/src/androidTest/java/nz/org/cacophony/birdmonitor/RecordAndSaveTest.java
@@ -1,109 +1,37 @@
 package nz.org.cacophony.birdmonitor;
 
-import android.content.Context;
 import android.support.test.espresso.Espresso;
-import android.support.test.espresso.IdlingRegistry;
-import android.support.test.filters.LargeTest;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.rule.GrantPermissionRule;
-import android.support.test.runner.AndroidJUnit4;
-import org.junit.*;
-import org.junit.runner.RunWith;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.io.File;
 
-import static android.Manifest.permission.*;
-import static android.support.test.InstrumentationRegistry.getInstrumentation;
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
-import static nz.org.cacophony.birdmonitor.HelperCode.nowSwipeLeft;
+import static nz.org.cacophony.birdmonitor.HelperCode.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@LargeTest
-@RunWith(AndroidJUnit4.class)
-public class RecordAndSaveTest {
-
-    private Context targetContext;
-    private Prefs prefs;
-
-    @Rule
-    public GrantPermissionRule permissionRule = GrantPermissionRule.grant(
-            WRITE_EXTERNAL_STORAGE,
-            RECORD_AUDIO,
-            ACCESS_FINE_LOCATION,
-            READ_PHONE_STATE);
-
-    @Rule
-    public final ActivityTestRule<MainActivity> mActivityTestRule = new ActivityTestRule<>(MainActivity.class);
-
-    @BeforeClass
-    public static void registerIdlingResource() {
-        IdlingRegistry.getInstance().register(IdlingResourceForEspressoTesting.createAccountIdlingResource);
-        IdlingRegistry.getInstance().register(IdlingResourceForEspressoTesting.registerPhoneIdlingResource);
-        IdlingRegistry.getInstance().register(IdlingResourceForEspressoTesting.uploadFilesIdlingResource);
-        IdlingRegistry.getInstance().register(IdlingResourceForEspressoTesting.recordIdlingResource);
-        IdlingRegistry.getInstance().register(IdlingResourceForEspressoTesting.signInIdlingResource);
-        IdlingRegistry.getInstance().register(IdlingResourceForEspressoTesting.anyWebRequestResource);
-    }
-
-    @AfterClass
-    public static void unregisterIdlingResource() {
-        IdlingRegistry.getInstance().unregister(IdlingResourceForEspressoTesting.createAccountIdlingResource);
-        IdlingRegistry.getInstance().unregister(IdlingResourceForEspressoTesting.registerPhoneIdlingResource);
-        IdlingRegistry.getInstance().unregister(IdlingResourceForEspressoTesting.uploadFilesIdlingResource);
-        IdlingRegistry.getInstance().unregister(IdlingResourceForEspressoTesting.recordIdlingResource);
-        IdlingRegistry.getInstance().unregister(IdlingResourceForEspressoTesting.signInIdlingResource);
-        IdlingRegistry.getInstance().unregister(IdlingResourceForEspressoTesting.anyWebRequestResource);
-    }
+public class RecordAndSaveTest extends TestBaseStartingOnSetupScreen {
 
     @Before
     public void setUpForRecord() throws InterruptedException {
-        targetContext = getInstrumentation().getTargetContext();
-        prefs = new Prefs(targetContext);
-        prefs.setInternetConnectionMode("normal");
-
-        if (prefs.getDeviceName() == null) {
-            // Welcome Dialog WILL be displayed - and SetupWizard will be running
-            HelperCode.dismissWelcomeDialog();
-        } else {
-            // Main menu will be showing
-            onView(withId(R.id.btnSetup)).perform(click());
-        }
-
-
-        Util.unregisterPhone(targetContext);
-        Util.signOutUser(targetContext);
-
-
-        nowSwipeLeft();
-        nowSwipeLeft(); // takes you to Sign In screen, which should be showing that user is signed in
-
-        // Need to sign in
+        nowNavigateRightTimes(2);
         HelperCode.signInUserTimhot();
-        Thread.sleep(1000); // had to put in sleep, as could not work out how to consistently get groups to display before testing code tries to choose a group
-
-        nowSwipeLeft(); // takes you to Groups screen
-
+        nowNavigateRight();
         HelperCode.registerPhone(prefs);
 
-        nowSwipeLeft(); // takes you to GPS
-        prefs.setIsDisabled(false);
-        nowSwipeLeft(); // takes you to Test RecordAndSaveOnPhone
+        nowNavigateRightTimes(2); // takes you to Test RecordAndSaveOnPhone
     }
 
     @After
     public void tearDownForRecord() {
-        prefs.setInternetConnectionMode("normal");
-        Util.signOutUser(targetContext);
-
         File recordingsFolder = Util.getRecordingsFolder(targetContext);
         for (File file : recordingsFolder.listFiles()) {
             file.delete();
         }
-
-        prefs.setIsDisabled(false);
     }
 
 
@@ -115,7 +43,6 @@ public class RecordAndSaveTest {
         int numberOfRecordingsBeforeTestRecord = Util.getNumberOfRecordings(targetContext);
 
         onView(withId(R.id.btnRecordNow)).perform(click());
-        prefs.setIsDisabled(true);
 
         int numberOfRecordingsAfterTestRecord = Util.getNumberOfRecordings(targetContext);
 
@@ -123,7 +50,7 @@ public class RecordAndSaveTest {
     }
 
     @Test
-    public void recordAndSaveOnServer() {
+    public void recordAndSaveOnServer() throws InterruptedException {
         // Need to put phone into normal mode so it uploads the recording
         prefs.setInternetConnectionMode("normal");
 
@@ -135,9 +62,8 @@ public class RecordAndSaveTest {
         prefs.setLastRecordIdReturnedFromServer(-1);
 
         onView(withId(R.id.btnRecordNow)).perform(click());
-        prefs.setIsDisabled(true);
 
-        Espresso.onIdle();
+        awaitIdlingResources();
 
         long lastRecordingIdFromServer = prefs.getLastRecordIdReturnedFromServer();
         assertTrue(lastRecordingIdFromServer > -1); // Don't know what the recording ID will be, so just check it exists

--- a/app/src/androidTest/java/nz/org/cacophony/birdmonitor/RegisterPhoneTest.java
+++ b/app/src/androidTest/java/nz/org/cacophony/birdmonitor/RegisterPhoneTest.java
@@ -1,86 +1,24 @@
 package nz.org.cacophony.birdmonitor;
 
 
-import android.content.Context;
-import android.support.test.espresso.IdlingRegistry;
-import android.support.test.filters.LargeTest;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.rule.GrantPermissionRule;
-import android.support.test.runner.AndroidJUnit4;
-import org.junit.*;
-import org.junit.runner.RunWith;
+import org.junit.Before;
+import org.junit.Test;
 
-import static android.Manifest.permission.ACCESS_FINE_LOCATION;
-import static android.support.test.InstrumentationRegistry.getInstrumentation;
 import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
-import static nz.org.cacophony.birdmonitor.HelperCode.nowSwipeLeft;
-import static nz.org.cacophony.birdmonitor.HelperCode.nowSwipeRight;
+import static nz.org.cacophony.birdmonitor.HelperCode.*;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@LargeTest
-@RunWith(AndroidJUnit4.class)
-public class RegisterPhoneTest {
-
-    private Context targetContext;
-    private Prefs prefs;
-
-    @Rule
-    public GrantPermissionRule permissionRule = GrantPermissionRule.grant(ACCESS_FINE_LOCATION);
-
-    @Rule
-    public final ActivityTestRule<MainActivity> mActivityTestRule = new ActivityTestRule<>(MainActivity.class);
-
-    @BeforeClass
-    public static void registerIdlingResource() {
-        IdlingRegistry.getInstance().register(IdlingResourceForEspressoTesting.createAccountIdlingResource);
-        IdlingRegistry.getInstance().register(IdlingResourceForEspressoTesting.registerPhoneIdlingResource);
-        IdlingRegistry.getInstance().register(IdlingResourceForEspressoTesting.anyWebRequestResource);
-    }
-
-    @AfterClass
-    public static void unregisterIdlingResource() {
-        IdlingRegistry.getInstance().unregister(IdlingResourceForEspressoTesting.createAccountIdlingResource);
-        IdlingRegistry.getInstance().unregister(IdlingResourceForEspressoTesting.registerPhoneIdlingResource);
-        IdlingRegistry.getInstance().unregister(IdlingResourceForEspressoTesting.anyWebRequestResource);
-    }
-
+public class RegisterPhoneTest extends TestBaseStartingOnSetupScreen {
 
     @Before
     public void setUpAndLogIn() throws InterruptedException {
-        targetContext = getInstrumentation().getTargetContext();
-        prefs = new Prefs(targetContext);
-        prefs.setInternetConnectionMode("normal");
-        prefs.setIsDisabled(false);
-
-        if (prefs.getDeviceName() == null) {
-            // Welcome Dialog WILL be displayed - and SetupWizard will be running
-            HelperCode.dismissWelcomeDialog();
-        } else {
-            // Main menu will be showing
-            onView(withId(R.id.btnSetup)).perform(click());
-        }
-
-        Util.unregisterPhone(targetContext);
-        Util.signOutUser(targetContext);
-
-        nowSwipeLeft();
-        nowSwipeLeft(); // takes you to Sign In screen, which should be showing that user is signed in
-
-        // Need to sign in
+        nowNavigateRightTimes(2);
         HelperCode.signInUserTimhot();
-        Thread.sleep(1000); // had to put in sleep, as could not work out how to consistently get groups to display before testing code tries to choose a group
-        nowSwipeLeft(); // takes you to Groups screen
-    }
-
-    @After
-    public void tearDownAndLogout() {
-        Util.signOutUser(targetContext);
-        prefs.setIsDisabled(true);
+        nowNavigateRight();
     }
 
     @Test
@@ -96,8 +34,8 @@ public class RegisterPhoneTest {
     public void unRegisterPhoneTest() throws InterruptedException {
         HelperCode.registerPhone(prefs);
 
-        nowSwipeLeft(); // need to go to next screen and back so that Un-register button displays
-        nowSwipeRight();
+        nowNavigateRight(); // need to go to next screen and back so that Un-register button displays
+        nowNavigateLeft();
 
         HelperCode.unRegisterPhone();
 

--- a/app/src/androidTest/java/nz/org/cacophony/birdmonitor/RegisterPhoneTest.java
+++ b/app/src/androidTest/java/nz/org/cacophony/birdmonitor/RegisterPhoneTest.java
@@ -17,7 +17,7 @@ public class RegisterPhoneTest extends TestBaseStartingOnSetupScreen {
     @Before
     public void setUpAndLogIn() throws InterruptedException {
         nowNavigateRightTimes(2);
-        HelperCode.signInUserTimhot();
+        HelperCode.signInPrimaryTestUser();
         nowNavigateRight();
     }
 

--- a/app/src/androidTest/java/nz/org/cacophony/birdmonitor/RootedTest.java
+++ b/app/src/androidTest/java/nz/org/cacophony/birdmonitor/RootedTest.java
@@ -1,49 +1,12 @@
 package nz.org.cacophony.birdmonitor;
 
-import android.content.Context;
-import android.support.test.espresso.IdlingRegistry;
-import android.support.test.filters.LargeTest;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.runner.AndroidJUnit4;
-import org.junit.*;
-import org.junit.runner.RunWith;
+import org.junit.After;
+import org.junit.Ignore;
+import org.junit.Test;
 
-import static android.support.test.InstrumentationRegistry.getInstrumentation;
 import static org.junit.Assert.assertTrue;
 
-@LargeTest
-@RunWith(AndroidJUnit4.class)
-public class RootedTest {
-
-    private Context targetContext;
-    private Prefs prefs;
-
-    @Rule
-    public final ActivityTestRule<MainActivity> mActivityTestRule = new ActivityTestRule<>(MainActivity.class);
-
-    @BeforeClass
-    public static void registerIdlingResource() {
-        IdlingRegistry.getInstance().register(IdlingResourceForEspressoTesting.rootedIdlingResource);
-    }
-
-    @AfterClass
-    public static void unregisterIdlingResource() {
-        IdlingRegistry.getInstance().unregister(IdlingResourceForEspressoTesting.rootedIdlingResource);
-    }
-
-    @Before
-    public void setUpForRooted() {
-        targetContext = getInstrumentation().getTargetContext();
-        prefs = new Prefs(targetContext);
-        prefs.setInternetConnectionMode("normal");
-        prefs.setIsDisabled(true); // stops recording upsetting test
-
-        if (prefs.getDeviceName() == null) {
-            // Welcome Dialog WILL be displayed - and SetupWizard will be running
-            HelperCode.dismissWelcomeDialog();
-        }
-    }
-
+public class RootedTest extends TestBaseStartingOnSetupScreen {
     @After
     public void tearDownForRooted() {
         // Leave with network access
@@ -57,7 +20,6 @@ public class RootedTest {
 
         // To prevent other tests failing due to phone going into airplane mode, change hasRoot to no
         prefs.setHasRootAccess(false);
-        prefs.setIsDisabled(true);
     }
 
 

--- a/app/src/androidTest/java/nz/org/cacophony/birdmonitor/SignInUserTest.java
+++ b/app/src/androidTest/java/nz/org/cacophony/birdmonitor/SignInUserTest.java
@@ -19,7 +19,7 @@ public class SignInUserTest extends TestBaseStartingOnSetupScreen {
 
     @Test
     public void signInTest() throws InterruptedException {
-        HelperCode.signInUserTimhot();
+        HelperCode.signInPrimaryTestUser();
 
         boolean userSignedIn = prefs.getUserSignedIn();
 

--- a/app/src/androidTest/java/nz/org/cacophony/birdmonitor/SignInUserTest.java
+++ b/app/src/androidTest/java/nz/org/cacophony/birdmonitor/SignInUserTest.java
@@ -1,67 +1,20 @@
 package nz.org.cacophony.birdmonitor;
 
-import android.content.Context;
-import android.support.test.espresso.IdlingRegistry;
-import android.support.test.filters.LargeTest;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.runner.AndroidJUnit4;
-import org.junit.*;
-import org.junit.runner.RunWith;
+import org.junit.Before;
+import org.junit.Test;
 
-import static android.support.test.InstrumentationRegistry.getInstrumentation;
 import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
-import static nz.org.cacophony.birdmonitor.HelperCode.nowSwipeLeft;
+import static nz.org.cacophony.birdmonitor.HelperCode.nowNavigateRightTimes;
 import static org.junit.Assert.assertTrue;
 
-@LargeTest
-@RunWith(AndroidJUnit4.class)
-public class SignInUserTest {
-
-    private Prefs prefs;
-
-    @Rule
-    public final ActivityTestRule<MainActivity> mActivityTestRule = new ActivityTestRule<>(MainActivity.class);
-
-    @BeforeClass
-    public static void registerIdlingResource() {
-        IdlingRegistry.getInstance().register(IdlingResourceForEspressoTesting.createAccountIdlingResource);
-        IdlingRegistry.getInstance().register(IdlingResourceForEspressoTesting.registerPhoneIdlingResource);
-        IdlingRegistry.getInstance().register(IdlingResourceForEspressoTesting.signInIdlingResource);
-        IdlingRegistry.getInstance().register(IdlingResourceForEspressoTesting.anyWebRequestResource);
-    }
-
-    @AfterClass
-    public static void unregisterIdlingResource() {
-        IdlingRegistry.getInstance().unregister(IdlingResourceForEspressoTesting.createAccountIdlingResource);
-        IdlingRegistry.getInstance().unregister(IdlingResourceForEspressoTesting.registerPhoneIdlingResource);
-        IdlingRegistry.getInstance().unregister(IdlingResourceForEspressoTesting.signInIdlingResource);
-        IdlingRegistry.getInstance().unregister(IdlingResourceForEspressoTesting.anyWebRequestResource);
-    }
+public class SignInUserTest extends TestBaseStartingOnSetupScreen {
 
     @Before
     public void setUpForSignInUser() {
-        Context targetContext = getInstrumentation().getTargetContext();
-        prefs = new Prefs(targetContext);
-        prefs.setInternetConnectionMode("normal");
-        prefs.setUserSignedIn(false);
-
-        if (prefs.getDeviceName() == null) {
-            // Welcome Dialog WILL be displayed - and SetupWizard will be running
-            HelperCode.dismissWelcomeDialog();
-        } else {
-            // Main menu will be showing
-
-            onView(withId(R.id.btnSetup)).perform(click());
-        }
-
-        HelperCode.useTestServerAndShortRecordings();
-
-        nowSwipeLeft();
-        nowSwipeLeft(); // takes you to Sign In screen
+        nowNavigateRightTimes(2);
     }
 
     @Test

--- a/app/src/androidTest/java/nz/org/cacophony/birdmonitor/TestBaseStartingOnMainScreen.java
+++ b/app/src/androidTest/java/nz/org/cacophony/birdmonitor/TestBaseStartingOnMainScreen.java
@@ -1,0 +1,24 @@
+package nz.org.cacophony.birdmonitor;
+
+import org.junit.Before;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static nz.org.cacophony.birdmonitor.HelperCode.nowNavigateRight;
+import static nz.org.cacophony.birdmonitor.HelperCode.nowNavigateRightTimes;
+
+public abstract class TestBaseStartingOnMainScreen extends TestBaseStartingOnSetupScreen {
+
+    @Before
+    public final void goToMainScreen() throws InterruptedException {
+        nowNavigateRightTimes(2);
+        HelperCode.signInUserTimhot();
+        nowNavigateRight();
+        HelperCode.registerPhone(prefs);
+        nowNavigateRightTimes(3);
+        onView(withId(R.id.btnFinished)).perform(click());
+        Thread.sleep(500);
+    }
+
+}

--- a/app/src/androidTest/java/nz/org/cacophony/birdmonitor/TestBaseStartingOnMainScreen.java
+++ b/app/src/androidTest/java/nz/org/cacophony/birdmonitor/TestBaseStartingOnMainScreen.java
@@ -17,7 +17,7 @@ public abstract class TestBaseStartingOnMainScreen extends TestBaseStartingOnSet
     @Before
     public final void goToMainScreen() throws InterruptedException {
         nowNavigateRightTimes(2);
-        HelperCode.signInUserTimhot();
+        HelperCode.signInPrimaryTestUser();
         nowNavigateRight();
         HelperCode.registerPhone(prefs);
         nowNavigateRightTimes(3);

--- a/app/src/androidTest/java/nz/org/cacophony/birdmonitor/TestBaseStartingOnMainScreen.java
+++ b/app/src/androidTest/java/nz/org/cacophony/birdmonitor/TestBaseStartingOnMainScreen.java
@@ -8,6 +8,10 @@ import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static nz.org.cacophony.birdmonitor.HelperCode.nowNavigateRight;
 import static nz.org.cacophony.birdmonitor.HelperCode.nowNavigateRightTimes;
 
+/**
+ * This test class provides all the same initial state as {@link TestBaseStartingOnSetupScreen}.
+ * In addition, these test cases will be logged in to the test user, device registered, and on the main screen.
+ */
 public abstract class TestBaseStartingOnMainScreen extends TestBaseStartingOnSetupScreen {
 
     @Before

--- a/app/src/androidTest/java/nz/org/cacophony/birdmonitor/TestBaseStartingOnSetupScreen.java
+++ b/app/src/androidTest/java/nz/org/cacophony/birdmonitor/TestBaseStartingOnSetupScreen.java
@@ -20,12 +20,16 @@ import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 
+/**
+ * This test class provides a base for any UI test. It resets the state to fully reset on the setup screen before each test.
+ * The default initial state is on the setup screen, logged out, with automatic recording disabled, test server and short recordings enabled.
+ */
 @LargeTest
 @RunWith(AndroidJUnit4.class)
 public abstract class TestBaseStartingOnSetupScreen {
 
-    protected Context targetContext;
-    protected Prefs prefs;
+    Context targetContext;
+    Prefs prefs;
 
     private Map<String, ?> prefsBackup;
 

--- a/app/src/androidTest/java/nz/org/cacophony/birdmonitor/TestBaseStartingOnSetupScreen.java
+++ b/app/src/androidTest/java/nz/org/cacophony/birdmonitor/TestBaseStartingOnSetupScreen.java
@@ -7,6 +7,7 @@ import android.support.test.filters.LargeTest;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.rule.GrantPermissionRule;
 import android.support.test.runner.AndroidJUnit4;
+import nz.org.cacophony.birdmonitor.views.MainActivity;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;

--- a/app/src/androidTest/java/nz/org/cacophony/birdmonitor/TestBaseStartingOnSetupScreen.java
+++ b/app/src/androidTest/java/nz/org/cacophony/birdmonitor/TestBaseStartingOnSetupScreen.java
@@ -1,0 +1,94 @@
+package nz.org.cacophony.birdmonitor;
+
+import android.content.Context;
+import android.support.test.espresso.IdlingRegistry;
+import android.support.test.espresso.idling.CountingIdlingResource;
+import android.support.test.filters.LargeTest;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.rule.GrantPermissionRule;
+import android.support.test.runner.AndroidJUnit4;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+
+import java.util.Map;
+
+import static android.Manifest.permission.*;
+import static android.support.test.InstrumentationRegistry.getInstrumentation;
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public abstract class TestBaseStartingOnSetupScreen {
+
+    protected Context targetContext;
+    protected Prefs prefs;
+
+    private Map<String, ?> prefsBackup;
+
+    @Rule
+    public final GrantPermissionRule permissionRule = GrantPermissionRule.grant(
+            WRITE_EXTERNAL_STORAGE,
+            RECORD_AUDIO,
+            ACCESS_FINE_LOCATION,
+            READ_PHONE_STATE);
+
+    @Rule
+    public final ActivityTestRule<MainActivity> initialActivityTestRule = new ActivityTestRule<>(MainActivity.class);
+
+    @Before
+    public final void baseInit() {
+        initIdlingResources();
+
+        targetContext = getInstrumentation().getTargetContext();
+        prefs = new Prefs(targetContext);
+
+        prefsBackup = HelperCode.backupPrefs(targetContext);
+
+        goToSetupPage(); // Need to do this before altering the settings otherwise we may expect different popup than is actually present
+
+        prefs.setInternetConnectionMode("normal");
+        prefs.setAutomaticRecordingsDisabled(true);
+        HelperCode.signOutUserAndDevice(prefs);
+        HelperCode.useTestServerAndShortRecordings();
+        prefs.setVeryAdvancedSettingsEnabled(false);
+    }
+
+    @After
+    public final void baseTearDown() {
+        resetIdlingResources();
+        HelperCode.restorePrefs(targetContext, prefsBackup);
+    }
+
+    private void goToSetupPage() {
+        if (prefs.getDeviceName() == null) {
+            // Welcome Dialog WILL be displayed - and SetupWizard will be running
+            HelperCode.dismissWelcomeDialog();
+        } else {
+            // Main menu will be showing
+            onView(withId(R.id.btnSetup)).perform(click());
+        }
+    }
+
+    private void initIdlingResources() {
+        for (CountingIdlingResource idlingResource : IdlingResourceForEspressoTesting.allIdlingResources) {
+            while (!idlingResource.isIdleNow()) {
+                idlingResource.decrement();
+            }
+            IdlingRegistry.getInstance().register(idlingResource);
+        }
+    }
+
+    private void resetIdlingResources() {
+        for (CountingIdlingResource idlingResource : IdlingResourceForEspressoTesting.allIdlingResources) {
+            while (!idlingResource.isIdleNow()) {
+                idlingResource.decrement();
+            }
+            IdlingRegistry.getInstance().unregister(idlingResource);
+        }
+    }
+
+}

--- a/app/src/androidTest/java/nz/org/cacophony/birdmonitor/UploadRecordingsTest.java
+++ b/app/src/androidTest/java/nz/org/cacophony/birdmonitor/UploadRecordingsTest.java
@@ -17,7 +17,7 @@ public class UploadRecordingsTest extends TestBaseStartingOnSetupScreen {
     @Before
     public void setUpForUploadAllRecordings() throws InterruptedException {
         nowNavigateRightTimes(2);
-        HelperCode.signInUserTimhot();
+        HelperCode.signInPrimaryTestUser();
         nowNavigateRight();
         HelperCode.registerPhone(prefs);
 

--- a/app/src/androidTest/java/nz/org/cacophony/birdmonitor/UploadRecordingsTest.java
+++ b/app/src/androidTest/java/nz/org/cacophony/birdmonitor/UploadRecordingsTest.java
@@ -1,99 +1,33 @@
 package nz.org.cacophony.birdmonitor;
 
-import android.content.Context;
-import android.support.test.espresso.IdlingRegistry;
-import android.support.test.filters.LargeTest;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.rule.GrantPermissionRule;
-import android.support.test.runner.AndroidJUnit4;
-import org.junit.*;
-import org.junit.runner.RunWith;
+import android.support.test.espresso.Espresso;
+import org.junit.Before;
+import org.junit.Test;
 
-import static android.Manifest.permission.*;
-import static android.support.test.InstrumentationRegistry.getInstrumentation;
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
-import static nz.org.cacophony.birdmonitor.HelperCode.nowSwipeLeft;
+import static nz.org.cacophony.birdmonitor.HelperCode.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@LargeTest
-@RunWith(AndroidJUnit4.class)
-public class UploadRecordingsTest {
-
-    private Context targetContext;
-    private Prefs prefs;
-
-    @Rule
-    public final ActivityTestRule<MainActivity> mActivityTestRule = new ActivityTestRule<>(MainActivity.class);
-
-    @Rule
-    public GrantPermissionRule permissionRule = GrantPermissionRule.grant(
-            WRITE_EXTERNAL_STORAGE,
-            RECORD_AUDIO,
-            ACCESS_FINE_LOCATION,
-            READ_PHONE_STATE);
-
-    @BeforeClass
-    public static void registerIdlingResource() {
-        IdlingRegistry.getInstance().register(IdlingResourceForEspressoTesting.recordIdlingResource);
-        IdlingRegistry.getInstance().register(IdlingResourceForEspressoTesting.uploadFilesIdlingResource);
-        IdlingRegistry.getInstance().register(IdlingResourceForEspressoTesting.signInIdlingResource);
-        IdlingRegistry.getInstance().register(IdlingResourceForEspressoTesting.anyWebRequestResource);
-    }
-
-    @AfterClass
-    public static void unregisterIdlingResource() {
-        IdlingRegistry.getInstance().unregister(IdlingResourceForEspressoTesting.recordIdlingResource);
-        IdlingRegistry.getInstance().unregister(IdlingResourceForEspressoTesting.uploadFilesIdlingResource);
-        IdlingRegistry.getInstance().unregister(IdlingResourceForEspressoTesting.signInIdlingResource);
-        IdlingRegistry.getInstance().unregister(IdlingResourceForEspressoTesting.anyWebRequestResource);
-    }
+public class UploadRecordingsTest extends TestBaseStartingOnSetupScreen {
 
     @Before
     public void setUpForUploadAllRecordings() throws InterruptedException {
-        targetContext = getInstrumentation().getTargetContext();
-        prefs = new Prefs(targetContext);
-        prefs.setInternetConnectionMode("normal");
-
-        if (prefs.getDeviceName() == null) {
-            // Welcome Dialog WILL be displayed - and SetupWizard will be running
-            HelperCode.dismissWelcomeDialog();
-        } else {
-            // Main menu will be showing
-
-            onView(withId(R.id.btnSetup)).perform(click());
-        }
-
-        Util.unregisterPhone(targetContext);
-        Util.signOutUser(targetContext);
-
-        nowSwipeLeft();
-        nowSwipeLeft(); // takes you to Sign In screen, which should be showing that user is signed in
-
-        // Need to sign in
+        nowNavigateRightTimes(2);
         HelperCode.signInUserTimhot();
-        Thread.sleep(1000); // had to put in sleep, as could not work out how to consistently get groups to display before testing code tries to choose a group
-
-        nowSwipeLeft(); // takes you to Groups screen
-
+        nowNavigateRight();
         HelperCode.registerPhone(prefs);
 
-        nowSwipeLeft(); // takes you to GPS
-        nowSwipeLeft(); // takes you to Test RecordAndSaveOnPhone
+        nowNavigateRightTimes(2); // takes you to Test RecordAndSaveOnPhone
 
         // Need to put phone into offline mode so it doesn't try to upload the recording
         prefs.setInternetConnectionMode("offline");
 
-        prefs.setIsDisabled(false);
-
         onView(withId(R.id.btnRecordNow)).perform(click());
-
-        // Need to stop app trying to make more recordings as this stuffs up the upload files idling resource count
-        prefs.setIsDisabled(true);
 
         onView(withId(R.id.btnFinished)).perform(click());
 
@@ -102,21 +36,15 @@ public class UploadRecordingsTest {
         prefs.setLastRecordIdReturnedFromServer(-1);
     }
 
-    @After
-    public void tearDownForDeleteAllRecordings() {
-        prefs.setInternetConnectionMode("normal");
-        prefs.setIsDisabled(false);
-        Util.signOutUser(targetContext);
-    }
-
-
     @Test
-    public void uploadRecordings() {
+    public void uploadRecordings() throws InterruptedException {
         int numberOfRecordingsBeforeUpload = Util.getNumberOfRecordings(targetContext);
         assertTrue(numberOfRecordingsBeforeUpload > 0);
         prefs.setInternetConnectionMode("normal");
 
         onView(withId(R.id.btnUploadFiles)).perform(click());
+
+        awaitIdlingResources();
 
         int numberOfRecordingsAfterDelete = Util.getNumberOfRecordings(targetContext);
         assertEquals(0, numberOfRecordingsAfterDelete);

--- a/app/src/androidTest/java/nz/org/cacophony/birdmonitor/UploadRecordingsTest.java
+++ b/app/src/androidTest/java/nz/org/cacophony/birdmonitor/UploadRecordingsTest.java
@@ -1,6 +1,5 @@
 package nz.org.cacophony.birdmonitor;
 
-import android.support.test.espresso.Espresso;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -68,7 +68,7 @@
             android:label="@string/activity_or_fragment_title_gps_location"
             android:screenOrientation="portrait" />
         <activity
-            android:name=".DisableActivity"
+            android:name=".DisableAutomaticRecordingActivity"
             android:label="@string/activity_or_fragment_title_turn_off_or_on"
             android:screenOrientation="portrait" />
         <activity

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/AdvancedWizardActivity.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/AdvancedWizardActivity.java
@@ -91,7 +91,7 @@ public class AdvancedWizardActivity extends AppCompatActivity {
 
 
         Prefs prefs = new Prefs(this);
-        if (prefs.getSettingsForTestServerEnabled()) {
+        if (prefs.getVeryAdvancedSettingsEnabled()) {
             setNumberOfPagesForVeryAdvanced();
         } else {
             setNumberOfPagesForAdvanced();

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/BirdCountActivity.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/BirdCountActivity.java
@@ -28,7 +28,7 @@ import org.json.JSONObject;
 
 import java.io.File;
 
-public class BirdCountActivity extends AppCompatActivity implements IdlingResourceForEspressoTesting {
+public class BirdCountActivity extends AppCompatActivity {
 
     private static final String TAG = BirdCountActivity.class.getName();
 

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/CreateAccountFragment.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/CreateAccountFragment.java
@@ -16,10 +16,7 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
-
 import org.json.JSONObject;
-
-import static nz.org.cacophony.birdmonitor.IdlingResourceForEspressoTesting.createAccountIdlingResource;
 
 public class CreateAccountFragment extends Fragment {
     private static final String TAG = "CreateAccountFragment";
@@ -160,8 +157,6 @@ public class CreateAccountFragment extends Fragment {
 
         tvMessages.setText(getString(R.string.attempting_to_creat));
 
-        createAccountIdlingResource.increment();
-
         signUp(username, emailAddress, etPassword1, getActivity().getApplicationContext());
     }
 
@@ -223,7 +218,6 @@ public class CreateAccountFragment extends Fragment {
 
                         // tvMessages.setVisibility(View.VISIBLE); // not sure if setText will cause an error if it isn't visible?
                         tvMessages.setText(messageToDisplay + "\n\nSwipe to next screen to sign in.");
-                        createAccountIdlingResource.decrement();
 
                     } else {
                         tilUsername.setVisibility(View.VISIBLE);
@@ -232,7 +226,6 @@ public class CreateAccountFragment extends Fragment {
                         tilPassword2.setVisibility(View.VISIBLE);
                         tvMessages.setText("");
                         ((SetupWizardActivity) getActivity()).displayOKDialogMessage("Error", messageToDisplay);
-                        createAccountIdlingResource.decrement();
                     }
 
                 }
@@ -246,7 +239,6 @@ public class CreateAccountFragment extends Fragment {
                 tilEmail.setVisibility(View.VISIBLE);
                 tilPassword1.setVisibility(View.VISIBLE);
                 tilPassword2.setVisibility(View.VISIBLE);
-                createAccountIdlingResource.decrement();
             }
         }
     };

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/DisableAutomaticRecordingActivity.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/DisableAutomaticRecordingActivity.java
@@ -9,8 +9,8 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.Switch;
 
-public class DisableActivity extends AppCompatActivity {
-    private static final String TAG = DisableActivity.class.getName();
+public class DisableAutomaticRecordingActivity extends AppCompatActivity {
+    private static final String TAG = DisableAutomaticRecordingActivity.class.getName();
 
     private Switch switchDisable;
 
@@ -18,7 +18,7 @@ public class DisableActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_disable);
+        setContentView(R.layout.activity_disable_automatic_recording);
 
         //https://developer.android.com/training/appbar/setting-up#java
         Toolbar myToolbar = findViewById(R.id.my_toolbar);
@@ -32,7 +32,7 @@ public class DisableActivity extends AppCompatActivity {
             if (!buttonView.isShown()) {
                 return;
             }
-            prefs.setIsDisabled(!isChecked);
+            prefs.setAutomaticRecordingsDisabled(!isChecked);
             displayOrHideGUIObjects();
 
         });
@@ -56,7 +56,7 @@ public class DisableActivity extends AppCompatActivity {
 
     void displayOrHideGUIObjects() {
         Prefs prefs = new Prefs(getApplicationContext());
-        boolean isDisabled = prefs.getIsDisabled();
+        boolean isDisabled = prefs.getAutomaticRecordingsDisabled();
 
         switchDisable.setChecked(!isDisabled);
 

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/GroupsFragment.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/GroupsFragment.java
@@ -15,8 +15,6 @@ import android.view.ViewGroup;
 import android.widget.*;
 import org.json.JSONObject;
 
-import static nz.org.cacophony.birdmonitor.IdlingResourceForEspressoTesting.getGroupsIdlingResource;
-
 public class GroupsFragment extends Fragment {
     private static final String TAG = "GroupsFragment";
 
@@ -142,35 +140,24 @@ public class GroupsFragment extends Fragment {
                         tvMessages.setText("");
                         resetGroups();
 
-                        getGroupsIdlingResource.decrement();
-
                     } else if (messageType.equalsIgnoreCase("FAILED_TO_ADD_GROUP")) {
                         ((SetupWizardActivity) getActivity()).displayOKDialogMessage("Error", messageToDisplay);
                         ((SetupWizardActivity) getActivity()).setGroup(null);
 
                         resetGroups();
-                        getGroupsIdlingResource.decrement();
                     } else if (messageType.equalsIgnoreCase("SUCCESSFULLY_RETRIEVED_GROUPS")) {
 
                         resetGroups();
-                        getGroupsIdlingResource.decrement();
 
                     } else if (messageType.equalsIgnoreCase("FAILED_TO_RETRIEVE_GROUPS")) {
                         ((SetupWizardActivity) getActivity()).displayOKDialogMessage("Error", messageToDisplay);
-                        getGroupsIdlingResource.decrement();
                     }
 
                 }
 
 
             } catch (Exception ex) {
-
                 Log.e(TAG, ex.getLocalizedMessage(), ex);
-                try {
-                    getGroupsIdlingResource.decrement();
-                } catch (Exception e) {
-                    Log.e(TAG, e.getLocalizedMessage(), e);
-                }
             }
         }
     };

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/IdlingResourceForEspressoTesting.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/IdlingResourceForEspressoTesting.java
@@ -2,6 +2,9 @@ package nz.org.cacophony.birdmonitor;
 
 import android.support.test.espresso.idling.CountingIdlingResource;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * This interface (used by the main activities) enables the espresso testing framework to wait for long running background
  * operations (such as uploading a recording) to finish, before the espresso test moves to the next
@@ -17,7 +20,14 @@ interface IdlingResourceForEspressoTesting {
     CountingIdlingResource createAccountIdlingResource = new CountingIdlingResource("CREATE_ACCOUNT");
     CountingIdlingResource recordIdlingResource = new CountingIdlingResource("RECORD");
     CountingIdlingResource uploadFilesIdlingResource = new CountingIdlingResource("UPLOAD_FILES");
-    CountingIdlingResource rootedIdlingResource = new CountingIdlingResource("ROOT");
     CountingIdlingResource anyWebRequestResource = new CountingIdlingResource("ANY_WEB_REQUEST");
 
+    List<CountingIdlingResource> allIdlingResources = Arrays.asList(
+            signInIdlingResource,
+            getGroupsIdlingResource,
+            registerPhoneIdlingResource,
+            createAccountIdlingResource,
+            recordIdlingResource,
+            uploadFilesIdlingResource,
+            anyWebRequestResource);
 }

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/MainActivity.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/MainActivity.java
@@ -17,7 +17,7 @@ import android.view.View;
 import android.widget.Button;
 
 
-public class MainActivity extends AppCompatActivity implements IdlingResourceForEspressoTesting {
+public class MainActivity extends AppCompatActivity {
     // Register with idling counter
     // https://developer.android.com/training/testing/espresso/idling-resource.html
     // stackoverflow.com/questions/25470210/using-espresso-idling-resource-with-multiple-activities // this gave me idea to use an interface for app under test activities e.g MainActivity
@@ -76,16 +76,16 @@ public class MainActivity extends AppCompatActivity implements IdlingResourceFor
             prefs.setDateTimeLastUpload(0);
             prefs.setInternetConnectionMode("normal");
             prefs.setAudioSource("MIC");
-            prefs.setIsDisabled(false);
+            prefs.setAutomaticRecordingsDisabled(false);
             prefs.setIsDisableDawnDuskRecordings(false);
-            prefs.setSettingsForTestServerEnabled(false);
+            prefs.setVeryAdvancedSettingsEnabled(false);
 
             prefs.setIsFirstTimeFalse();
         }
 
         final Button advancedButton = findViewById(R.id.btnAdvanced);
 
-        if (prefs.getSettingsForTestServerEnabled()) {
+        if (prefs.getVeryAdvancedSettingsEnabled()) {
             advancedButton.setText(getResources().getString(R.string.very_advanced));
         }
 
@@ -100,13 +100,13 @@ public class MainActivity extends AppCompatActivity implements IdlingResourceFor
                     long timeBetweenDownAndUp = advancedButtonUpTime - advancedButtonDownTime;
 
                     if (timeBetweenDownAndUp > 5000) {
-                        if (prefs.getSettingsForTestServerEnabled()) {
+                        if (prefs.getVeryAdvancedSettingsEnabled()) {
                             advancedButton.setText(getResources().getString(R.string.advanced));
-                            prefs.setSettingsForTestServerEnabled(false);
+                            prefs.setVeryAdvancedSettingsEnabled(false);
 
                         } else {
                             advancedButton.setText(getResources().getString(R.string.very_advanced));
-                            prefs.setSettingsForTestServerEnabled(true);
+                            prefs.setVeryAdvancedSettingsEnabled(true);
 
                         }
 
@@ -148,7 +148,7 @@ public class MainActivity extends AppCompatActivity implements IdlingResourceFor
         Prefs prefs = new Prefs(this.getApplicationContext());
 
 
-        if (prefs.getIsDisabled()) {
+        if (prefs.getAutomaticRecordingsDisabled()) {
             ((Button) findViewById(R.id.btnDisable)).setText(getResources().getString(R.string.enable_recording));
             findViewById(R.id.btnDisable).setBackgroundColor(getResources().getColor(R.color.recordingDisabledButton));
         } else {
@@ -235,7 +235,7 @@ public class MainActivity extends AppCompatActivity implements IdlingResourceFor
 
     public void launchDisableActivity(@SuppressWarnings("UnusedParameters") View v) {
         try {
-            Intent intent = new Intent(this, DisableActivity.class);
+            Intent intent = new Intent(this, DisableAutomaticRecordingActivity.class);
             startActivity(intent);
         } catch (Exception ex) {
             Log.e(TAG, ex.getLocalizedMessage(), ex);

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/Prefs.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/Prefs.java
@@ -12,8 +12,9 @@ import android.util.Log;
 class Prefs {
 
     private static final String TAG = Prefs.class.getName();
-    private final Context context;
-    private static final String PREFS_NAME = "CacophonyPrefs";
+
+    static final String PREFS_NAME = "CacophonyPrefs";
+
     private static final String PRODUCTION_CACOPHONY_PROJECT_WEBSITE_BROWSE_RECORDINGS = "https://browse.cacophony.org.nz/";
     private static final String TEST_CACOPHONY_PROJECT_WEBSITE_BROWSE_RECORDINGS = "https://browse-test.cacophony.org.nz/";
     private static final String PRODUCTION_SERVER_HOST = "api.cacophony.org.nz";
@@ -104,14 +105,15 @@ class Prefs {
     private static final String INTERNET_CONNECTION_MODE_KEY = "INTERNET_CONNECTION_MODE";
     private static final String AUDIO_SOURCE_KEY = "AUDIO_SOURCE";
     private static final String BIRD_COUNT_DURATION_KEY = "BIRD_COUNT_DURATION";
-    private static final String DISABLED_KEY = "DISABLED";
+    private static final String AUTOMATIC_RECORDINGS_DISABLED_KEY = "DISABLED";
     private static final String DISABLED_DAWN_DUSK_RECORDINGS_KEY = "DISABLED_DAWN_DUSK_RECORDINGS";
-    private static final String SETTINGS_FOR_TEST_SERVER_ENABLED_KEY = "SETTINGS_FOR_TEST_SERVER_ENABLED";
+    private static final String VERY_ADVANCED_SETTINGS_ENABLED_KEY = "SETTINGS_FOR_TEST_SERVER_ENABLED";
     private static final String GROUPS_KEY = "GROUPS";
     private static final String USER_SIGNED_IN_KEY = "USER_SIGNED_IN";
     private static final String LAST_DEVICE_NAME_USED_FOR_TESTING_KEY = "LAST_PASSWORD_USED_FOR_TESTING";
     private static final String LATEST_BIRD_COUNT_RECORDING_FILE_NAME_KEY = "LATEST_RECORDING_FILE_NAME";
 
+    private final Context context;
 
     public Prefs(Context context) {
         this.context = context;
@@ -630,12 +632,12 @@ class Prefs {
         setString(BIRD_COUNT_DURATION_KEY, birdCountDuration);
     }
 
-    void setIsDisabled(boolean isDisabled) {
-        setBoolean(DISABLED_KEY, isDisabled);
+    void setAutomaticRecordingsDisabled(boolean isDisabled) {
+        setBoolean(AUTOMATIC_RECORDINGS_DISABLED_KEY, isDisabled);
     }
 
-    boolean getIsDisabled() {
-        return getBoolean(DISABLED_KEY);
+    boolean getAutomaticRecordingsDisabled() {
+        return getBoolean(AUTOMATIC_RECORDINGS_DISABLED_KEY);
     }
 
     void setIsDisableDawnDuskRecordings(boolean isDisabled) {
@@ -646,12 +648,12 @@ class Prefs {
         return getBoolean(DISABLED_DAWN_DUSK_RECORDINGS_KEY);
     }
 
-    void setSettingsForTestServerEnabled(boolean isEnabled) {
-        setBoolean(SETTINGS_FOR_TEST_SERVER_ENABLED_KEY, isEnabled);
+    void setVeryAdvancedSettingsEnabled(boolean isEnabled) {
+        setBoolean(VERY_ADVANCED_SETTINGS_ENABLED_KEY, isEnabled);
     }
 
-    boolean getSettingsForTestServerEnabled() {
-        return getBoolean(SETTINGS_FOR_TEST_SERVER_ENABLED_KEY);
+    boolean getVeryAdvancedSettingsEnabled() {
+        return getBoolean(VERY_ADVANCED_SETTINGS_ENABLED_KEY);
     }
 
     void setGroups(String groups) {

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/RecordAndUpload.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/RecordAndUpload.java
@@ -20,13 +20,15 @@ import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
 import java.util.*;
 
+import static nz.org.cacophony.birdmonitor.IdlingResourceForEspressoTesting.recordIdlingResource;
+
 
 /**
  * This is where the action is - however the code starts, it gets here to do a recording and then
  * sends recording to server.
  */
 
-class RecordAndUpload implements IdlingResourceForEspressoTesting {
+class RecordAndUpload {
     private static final String TAG = RecordAndUpload.class.getName();
     public static boolean isRecording = false;
     private static boolean cancelUploadingRecordings = false;

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/RegisterFragment.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/RegisterFragment.java
@@ -19,7 +19,6 @@ import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
-
 import org.json.JSONObject;
 
 import static nz.org.cacophony.birdmonitor.IdlingResourceForEspressoTesting.registerPhoneIdlingResource;
@@ -119,14 +118,12 @@ public class RegisterFragment extends Fragment {
                             ((SetupWizardActivity) getActivity()).setNumberOfPagesForRegisterd();
                             etGroupNameInput.setEnabled(false);
                             etDeviceNameInput.setEnabled(false);
-                            registerPhoneIdlingResource.decrement();
 
                         } else if (messageType.equalsIgnoreCase("REGISTER_FAIL")) {
                             tvMessages.setText(messageToDisplay);
                             ((SetupWizardActivity) getActivity()).setNumberOfPagesForSignedInNotRegistered();
                             etGroupNameInput.setEnabled(true);
                             etDeviceNameInput.setEnabled(true);
-                            registerPhoneIdlingResource.decrement();
                         } else {
                             ((SetupWizardActivity) getActivity()).displayOKDialogMessage("Error", messageToDisplay);
                         }
@@ -139,7 +136,6 @@ public class RegisterFragment extends Fragment {
 
                 tvMessages.setText("Oops, your phone did not register - not sure why");
                 displayOrHideGUIObjects(true);
-                registerPhoneIdlingResource.decrement();
             }
         }
     };
@@ -273,7 +269,6 @@ public class RegisterFragment extends Fragment {
     }
 
     public void registerButtonPressed() {
-        //  registerIdlingResource.increment();
 
         Prefs prefs = new Prefs(getActivity().getApplicationContext());
 
@@ -403,11 +398,11 @@ public class RegisterFragment extends Fragment {
         try {
             Util.unregisterPhone(getActivity().getApplicationContext());
             ((SetupWizardActivity) getActivity()).setNumberOfPagesForSignedInNotRegistered();
-            tvMessages.setText("Success - Device is no longer registered");
             etGroupNameInput.setText("");
             etDeviceNameInput.setText("");
 
             displayOrHideGUIObjects(true);
+            tvMessages.setText("Success - Device is no longer registered");
 
         } catch (Exception ex) {
             Log.e(TAG, "Error Un-registering device.");

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/RootedFragment.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/RootedFragment.java
@@ -62,7 +62,7 @@ public class RootedFragment extends Fragment {
             swRooted.setText("NO");
         }
 
-        if (prefs.getSettingsForTestServerEnabled()) {
+        if (prefs.getVeryAdvancedSettingsEnabled()) {
             btnFinished.setVisibility(View.INVISIBLE);
         } else {
             btnFinished.setVisibility(View.VISIBLE);

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/Server.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/Server.java
@@ -14,8 +14,7 @@ import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.Date;
 
-import static nz.org.cacophony.birdmonitor.IdlingResourceForEspressoTesting.anyWebRequestResource;
-import static nz.org.cacophony.birdmonitor.IdlingResourceForEspressoTesting.uploadFilesIdlingResource;
+import static nz.org.cacophony.birdmonitor.IdlingResourceForEspressoTesting.*;
 
 
 /**
@@ -138,6 +137,7 @@ class Server {
     }
 
     static void loginUser(Context context) {
+        signInIdlingResource.increment();
 
         final Prefs prefs = new Prefs(context);
 
@@ -249,6 +249,8 @@ class Server {
             } catch (JSONException e2) {
                 Log.e(TAG, e2.getLocalizedMessage(), e2);
             }
+        } finally {
+            signInIdlingResource.decrement();
         }
     }
 
@@ -265,6 +267,7 @@ class Server {
         if (group == null || group.length() < 4) {
             Log.i(TAG, "Invalid group name: " + group);
             broadcastGenericError(context, "Group name must be at least 4 characters", "REGISTER_FAIL", "SERVER_REGISTER");
+            registerPhoneIdlingResource.decrement();
             return;
         }
 
@@ -323,6 +326,8 @@ class Server {
         } catch (Exception e) {
             Log.w(TAG, e);
             broadcastGenericError(context, "An unknown error occurred: " + e.toString(), "REGISTER_FAIL", "SERVER_REGISTER");
+        } finally {
+            registerPhoneIdlingResource.decrement();
         }
     }
 
@@ -352,6 +357,8 @@ class Server {
     }
 
     static void signUp(final String username, final String emailAddress, final String password, final Context context) {
+        createAccountIdlingResource.increment();
+
         final Prefs prefs = new Prefs(context);
 
         String signupUrl = prefs.getServerUrl() + SIGNUP_URL;
@@ -404,6 +411,8 @@ class Server {
         } catch (Exception e) {
             Log.w(TAG, e);
             broadcastGenericError(context, "An unknown error occured: " + e.toString(), "FAILED_TO_CREATE_USER", "SERVER_SIGNUP");
+        } finally {
+            createAccountIdlingResource.decrement();
         }
     }
 
@@ -489,6 +498,8 @@ class Server {
     }
 
     static ArrayList<String> getGroups(Context context) {
+        getGroupsIdlingResource.increment();
+
         final Prefs prefs = new Prefs(context);
 
         ArrayList<String> groups = new ArrayList<>();
@@ -536,6 +547,8 @@ class Server {
 
         } catch (Exception ex) {
             Log.e(TAG, ex.getLocalizedMessage(), ex);
+        } finally {
+            getGroupsIdlingResource.decrement();
         }
 
         return groups;

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/SignInFragment.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/SignInFragment.java
@@ -17,11 +17,7 @@ import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
-
 import org.json.JSONObject;
-
-import static nz.org.cacophony.birdmonitor.IdlingResourceForEspressoTesting.getGroupsIdlingResource;
-import static nz.org.cacophony.birdmonitor.IdlingResourceForEspressoTesting.signInIdlingResource;
 
 public class SignInFragment extends Fragment {
     private static final String TAG = "SignInFragment";
@@ -74,15 +70,12 @@ public class SignInFragment extends Fragment {
     }
 
     private void signInUser() {
-        signInIdlingResource.increment();
-        getGroupsIdlingResource.increment();
 
         disableFlightMode();
 
         // Now wait for network connection as setFlightMode takes a while
         if (!Util.waitForNetworkConnection(getActivity().getApplicationContext(), true)) {
             Log.e(TAG, "Failed to disable airplane mode");
-            signInIdlingResource.decrement();
             return;
         }
 
@@ -201,25 +194,21 @@ public class SignInFragment extends Fragment {
                         etPasswordInput.setText("");
 
                         Util.getGroupsFromServer(getActivity().getApplicationContext());
-                        signInIdlingResource.decrement();
 
                     } else if (messageType.equalsIgnoreCase("NETWORK_ERROR")) {
                         ((SetupWizardActivity) getActivity()).displayOKDialogMessage("Error", messageToDisplay);
                         etUserNameOrPasswordInput.setText(userNameOrEmailAddress);
-                        signInIdlingResource.decrement();
                         return;
 
                     } else if (messageType.equalsIgnoreCase("INVALID_CREDENTIALS")) {
                         ((SetupWizardActivity) getActivity()).displayOKDialogMessage("Error", messageToDisplay);
                         etUserNameOrPasswordInput.setText(userNameOrEmailAddress);
-                        signInIdlingResource.decrement();
                         return;
 
                     } else if (messageType.equalsIgnoreCase("UNABLE_TO_SIGNIN")) {
 
                         ((SetupWizardActivity) getActivity()).displayOKDialogMessage("Error", messageToDisplay);
                         etUserNameOrPasswordInput.setText(userNameOrEmailAddress);
-                        signInIdlingResource.decrement();
                         return;
                     }
 
@@ -228,7 +217,6 @@ public class SignInFragment extends Fragment {
             } catch (Exception ex) {
                 Log.e(TAG, ex.getLocalizedMessage(), ex);
                 ((SetupWizardActivity) getActivity()).displayOKDialogMessage("Error", "Could not login.");
-                signInIdlingResource.decrement();
             }
         }
     };

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/StartRecordingReceiver.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/StartRecordingReceiver.java
@@ -7,7 +7,6 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.PowerManager;
 import android.util.Log;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -93,7 +92,7 @@ public class StartRecordingReceiver extends BroadcastReceiver {
             wakeLock.acquire(wakeLockDuration);
 
 
-            if (prefs.getIsDisabled() && !recordButtonWasPressed) {
+            if (prefs.getAutomaticRecordingsDisabled() && !recordButtonWasPressed) {
                 jsonObjectMessageToBroadcast = new JSONObject();
                 jsonObjectMessageToBroadcast.put("messageType", "RECORDING_DISABLED");
                 jsonObjectMessageToBroadcast.put("messageToDisplay", "Recording is currently disabled on this phone");

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/VitalsActivity.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/VitalsActivity.java
@@ -32,7 +32,7 @@ import java.util.List;
  * app and the GPS loction.
  */
 @SuppressWarnings("NullableProblems")
-public class VitalsActivity extends AppCompatActivity implements IdlingResourceForEspressoTesting {
+public class VitalsActivity extends AppCompatActivity {
     // Register with idling counter
 // https://developer.android.com/training/testing/espresso/idling-resource.html
 // stackoverflow.com/questions/25470210/using-espresso-idling-resource-with-multiple-activities // this gave me idea to use an interface for app under test activities e.g MainActivity
@@ -170,7 +170,7 @@ public class VitalsActivity extends AppCompatActivity implements IdlingResourceF
         // Update time of next recording
         TextView tvNextRecording = findViewById(R.id.tvNextRecording);
 
-        if (prefs.getIsDisabled()) {
+        if (prefs.getAutomaticRecordingsDisabled()) {
             tvNextRecording.setText("Next Recording: Disabled - no next recording");
         } else {
             String nextAlarm = Util.getNextAlarm(getApplicationContext());

--- a/app/src/main/res/layout/activity_disable_automatic_recording.xml
+++ b/app/src/main/res/layout/activity_disable_automatic_recording.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="nz.org.cacophony.birdmonitor.DisableActivity">
+    tools:context="nz.org.cacophony.birdmonitor.DisableAutomaticRecordingActivity">
 
     <android.support.v7.widget.Toolbar
         android:id="@+id/my_toolbar"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,7 +63,7 @@
 
     <string name="text_1_welcome_fragment">\'Swipe\' the screen (left or right) to move through the setup wizard. You can exit the wizard at any stage by pressing your phone\'s back button.\n\nEach screen has extra information available from the help icon (top right).</string>
 
-    <string name="turn_off_the_bird_monitor">Turn off the Bird Monitor - No more recordings will be made (even after a restart).</string>
+    <string name="turn_off_the_bird_monitor">Turn off the Bird Monitor - No more automatic recordings will be made (even after a restart).</string>
     <string name="choose_the_internet_connection_mode">Choose the internet connection mode.  If you are not sure, read the help or just choose \'Normal\'.  Swipe to next screen when ready.</string>
 
     <string name="choose_the_audio_source_setting">Choose MediaRecorder.AudioSource setting</string>


### PR DESCRIPTION
Updated tests to inherit from a base test class that manages all the standard setup/teardown to reduce code duplication.

Made the tests fully restart/reset on each test case which makes them fully independent, they shouldn't rely on any initial state anymore.

Made all tests use the test server via the base test class.

Updated idlingResources to be incremented/decremented in the Server class mostly, to prevent issues with message handling. This has the downside that there might be slight gaps between idlingResources (e.g. sign in -> get groups). Doesn't seem to make the tests fail, but may be an issue if we want to remove sleeps.

Renamed a couple of things to be more clear/specific (disable -> disableAutomaticRecording; settingsForTestServerEnabled -> veryAdvancedSettingsEnabled)

Added extra library to allow "scroll" instead of "swipe" which is far more consistent for navigation.

Made preferences fully save/restore between each test so running tests on your real device leaves its settings consistent with how it was before.